### PR TITLE
Add P5.js examples to documentation

### DIFF
--- a/sketching-doc/sketching-doc/manual-examples/basics/color/brightness.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/color/brightness.js
@@ -1,0 +1,28 @@
+/**
+ * Brightness 
+ * by Rusty Robison. 
+ * 
+ * Brightness is the relative lightness or darkness of a color.
+ * Move the cursor vertically over each bar to alter its brightness. 
+ */
+ 
+var barWidth = 20;
+var lastBar = -1;
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  colorMode(HSB, width, 100, width);
+  noStroke();
+  background(0);
+}
+
+function draw() {
+  var whichBar = mouseX / barWidth;
+  if (whichBar != lastBar) {
+    var barX = whichBar * barWidth;
+    fill(barX, 100, mouseY);
+    rect(barX, 0, barWidth, height);
+    lastBar = whichBar;
+  }
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/color/color-variables.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/color/color-variables.js
@@ -1,0 +1,45 @@
+/**
+ * Color Variables (Homage to Albers). 
+ * 
+ * This example creates variables for colors that may be referred to 
+ * in the program by a name, rather than a number. 
+ */
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  noStroke();
+  background(51, 0, 0);
+
+  var inside = color(204, 102, 0);
+  var middle = color(204, 153, 0);
+  var outside = color(153, 51, 0);
+
+  // These statements are equivalent to the statements above.
+  // Programmers may use the format they prefer.
+  //color inside = #CC6600;
+  //color middle = #CC9900;
+  //color outside = #993300;
+
+  push();
+  translate(80, 80);
+  fill(outside);
+  rect(0, 0, 200, 200);
+  fill(middle);
+  rect(40, 60, 120, 120);
+  fill(inside);
+  rect(60, 90, 80, 80);
+  pop();
+
+  push();
+  translate(360, 80);
+  fill(inside);
+  rect(0, 0, 200, 200);
+  fill(outside);
+  rect(40, 60, 120, 120);
+  fill(middle);
+  rect(60, 90, 80, 80);
+  pop();
+
+  noLoop();
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/color/hue.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/color/hue.js
@@ -1,0 +1,31 @@
+/**
+ * Hue. 
+ * 
+ * Hue is the color reflected from or transmitted through an object 
+ * and is typically referred to as the name of the color (red, blue, yellow, etc.) 
+ * Move the cursor vertically over each bar to alter its hue. 
+ */
+ 
+var barWidth = 20;
+var lastBar = -1;
+
+function setup() 
+{
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  colorMode(HSB, height, height, height);  
+  noStroke();
+  background(0);
+}
+
+function draw() 
+{
+  var whichBar = mouseX / barWidth;
+  if (whichBar != lastBar) {
+    var barX = whichBar * barWidth;
+    fill(mouseY, height, height);
+    rect(barX, 0, barWidth, height);
+    lastBar = whichBar;
+  }
+}
+

--- a/sketching-doc/sketching-doc/manual-examples/basics/color/linear-gradient.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/color/linear-gradient.js
@@ -1,0 +1,56 @@
+/**
+ * Simple Linear Gradient 
+ * 
+ * The lerpColor() function is useful for interpolating
+ * between two colors.
+ */
+
+// Constants
+var Y_AXIS = 1;
+var X_AXIS = 2;
+var b1, b2, c1, c2;
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+
+  // Define colors
+  b1 = color(255);
+  b2 = color(0);
+  c1 = color(204, 102, 0);
+  c2 = color(0, 102, 153);
+
+  noLoop();
+}
+
+function draw() {
+  // Background
+  setGradient(0, 0, width/2, height, b1, b2, X_AXIS);
+  setGradient(width/2, 0, width/2, height, b2, b1, X_AXIS);
+  // Foreground
+  setGradient(50, 90, 540, 80, c1, c2, Y_AXIS);
+  setGradient(50, 190, 540, 80, c2, c1, X_AXIS);
+}
+
+function setGradient(x, y, w, h, c1, c2, axis ) {
+
+  noFill();
+
+  if (axis === Y_AXIS) {  // Top to bottom gradient
+    for (var i = y; i <= y+h; i++) {
+      var inter = map(i, y, y+h, 0, 1);
+      var c = lerpColor(c1, c2, inter);
+      stroke(c);
+      line(x, i, x+w, i);
+    }
+  }  
+  else if (axis === X_AXIS) {  // Left to right gradient
+    for (var i = x; i <= x+w; i++) {
+      var inter = map(i, x, x+w, 0, 1);
+      var c = lerpColor(c1, c2, inter);
+      stroke(c);
+      line(i, y, i, y+h);
+    }
+  }
+}
+

--- a/sketching-doc/sketching-doc/manual-examples/basics/color/radial-gradient.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/color/radial-gradient.js
@@ -1,0 +1,37 @@
+/**
+ * Radial Gradient. 
+ * 
+ * Draws a series of concentric circles to create a gradient 
+ * from one color to another.
+ */
+
+var dim;
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  dim = width/2;
+  background(0);
+  colorMode(HSB, 360, 100, 100);
+  noStroke();
+  ellipseMode(RADIUS);
+  frameRate(1);
+}
+
+function draw() {
+  background(0);
+  for (var x = 0; x <= width; x+=dim) {
+    drawGradient(x, height/2);
+  } 
+}
+
+function drawGradient(x, y) {
+  var radius = dim/2;
+  var h = random(0, 360);
+  for (var r = radius; r > 0; --r) {
+    fill(h, 90, 90);
+    ellipse(x, y, r, r);
+    h = (h + 1) % 360;
+  }
+}
+

--- a/sketching-doc/sketching-doc/manual-examples/basics/color/relativity.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/color/relativity.js
@@ -1,0 +1,43 @@
+/**
+ * Relativity. 
+ * 
+ * Each color is perceived in relation to other colors. The top and bottom 
+ * bars each contain the same component colors, but a different display order 
+ * causes individual colors to appear differently. 
+ */
+ 
+var a, b, c, d, e;
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  noStroke();
+  a = color(165, 167, 20);
+  b = color(77, 86, 59);
+  c = color(42, 106, 105);
+  d = color(165, 89, 20);
+  e = color(146, 150, 127);
+  noLoop();  // Draw only one time
+}
+
+function draw() {
+  drawBand(a, b, c, d, e, 0, width/128);
+  drawBand(c, a, d, b, e, height/2, width/128);
+}
+
+function drawBand(v, w, x, y, z, ypos, barWidth) {
+  var num = 5;
+  var colorOrder = [ v, w, x, y, z ];
+  for(var i = 0; i < width; i += barWidth*num) {
+    for(var j = 0; j < num; j++) {
+      fill(colorOrder[j]);
+      rect(i+j*barWidth, ypos, barWidth, height/2);
+    }
+  }
+}
+
+
+
+
+
+

--- a/sketching-doc/sketching-doc/manual-examples/basics/color/saturation.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/color/saturation.js
@@ -1,0 +1,30 @@
+/**
+ * Saturation. 
+ * 
+ * Saturation is the strength or purity of the color and represents the 
+ * amount of gray in proportion to the hue. A "saturated" color is pure 
+ * and an "unsaturated" color has a large percentage of gray. 
+ * Move the cursor vertically over each bar to alter its saturation. 
+ */
+ 
+var barWidth = 20;
+var lastBar = -1;
+
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  colorMode(HSB, width, height, 100); 
+  noStroke();
+}
+
+
+function draw() {
+  var whichBar = mouseX / barWidth;
+  if (whichBar != lastBar) {
+    var barX = whichBar * barWidth;
+    fill(barX, mouseY, 66);
+    rect(barX, 0, barWidth, height);
+    lastBar = whichBar;
+  }
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/color/wave-gradient.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/color/wave-gradient.js
@@ -1,0 +1,68 @@
+/**
+ * Wave Gradient 
+ * by Ira Greenberg.  
+ * 
+ * Generate a gradient along a sin() wave.
+ */
+
+var angle = 0;
+var px = 0, py = 0;
+var amplitude = 30;
+var frequency = 0;
+var fillGap = 2.5;
+var c;
+
+var gradient;
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  pixelDensity(1);
+  canvas.parent("p5container");
+  background(200);
+  gradient = createImage(width, height, RGB);
+  noLoop();
+}
+
+function draw() {
+  gradient.loadPixels();
+  for (var i =- 75; i < height+75; i++){
+    // Reset angle to 0, so waves stack properly
+    angle = 0;
+    // Increasing frequency causes more gaps
+    frequency+=.002;
+    for (var j = 0; j < width+75; j++){
+      py = i + sin(radians(angle)) * amplitude;
+      angle += frequency;
+      // c =  color(abs(py-i)*255/amplitude;, 255-abs(py-i)*255/amplitude, j*(255.0/(width+50)));
+      var r = int(abs(py-i)*255/amplitude);
+      var g = int(255-abs(py-i)*255/amplitude);
+      var b = int(j*(255.0/(width+50)));
+
+      // Hack to fill gaps. Raise value of fillGap if you increase frequency
+      for (var filler = 0; filler < fillGap; filler++){
+        var x = int(j-filler);
+        var y = int(py)-filler;
+
+        var index = (x + y * width)*4;
+        gradient.pixels[index] = r; gradient.pixels[index+1] = g; gradient.pixels[index+2] = b; gradient.pixels[index+3] = 255;
+
+        x = int(j);
+        y = int(py);
+        index = (x + y * width)*4;
+        gradient.pixels[index] = r; gradient.pixels[index+1] = g; gradient.pixels[index+2] = b; gradient.pixels[index+3] = 255;
+
+        x = int(j+filler);
+        y = int(py)+filler;
+        index = (x + y * width)*4;
+        gradient.pixels[index] = r; gradient.pixels[index+1] = g; gradient.pixels[index+2] = b; gradient.pixels[index+3] = 255;
+
+        //set(int(j-filler), int(py)-filler, c);
+        //set(int(j), int(py), c);
+        //set(int(j+filler), int(py)+filler, c);
+      }
+    }
+  }
+  gradient.updatePixels();
+  image(gradient, 0, 0);
+  noLoop();
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/color/wave-gradient.rkt
+++ b/sketching-doc/sketching-doc/manual-examples/basics/color/wave-gradient.rkt
@@ -12,7 +12,7 @@
 
 (define (setup)
   (size 640 360)
-  ; (background 200)
+  (background 200)
   (no-loop))
 
 (define (draw)

--- a/sketching-doc/sketching-doc/manual-examples/basics/color/wave-gradient.rkt
+++ b/sketching-doc/sketching-doc/manual-examples/basics/color/wave-gradient.rkt
@@ -12,12 +12,12 @@
 
 (define (setup)
   (size 640 360)
-  (background 200)
+  ; (background 200)
   (no-loop))
 
 (define (draw)
-  (define w/2 width #;(quotient width  2))
-  (define h/2 height #;(quotient height 2))
+  (define w/2 width)
+  (define h/2 height)
   ;; To efficiently set all the pixels on screen, make the set() 
   ;; calls on a PImage, then write the result to the screen.
   (define gradient (create-image width height 'rgb))
@@ -40,6 +40,4 @@
         (image-set gradient (+ w/2 (int    j))         (+ h/2    (int py))         c)
         (image-set gradient (+ w/2 (int (+ j filler))) (+ h/2 (+ (int py) filler)) c))))
   ;; Draw the image to the screen
-  ; (set 0 0 gradient)
-  ;;Another alternative for drawing to the screen
   (image gradient 0 0))

--- a/sketching-doc/sketching-doc/manual-examples/basics/form/ShapePrimitives.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/form/ShapePrimitives.js
@@ -1,0 +1,35 @@
+/**
+ * Shape Primitives. 
+ * 
+ * The basic shape primitive functions are triangle(),
+ * rect(), quad(), ellipse(), and arc(). Squares are made
+ * with rect() and circles are made with ellipse(). Each 
+ * of these functions requires a number of parameters to 
+ * determine the shape's position and size. 
+ */
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  background(0);
+  noStroke();
+
+  fill(204);
+  triangle(18, 18, 18, 360, 81, 360);
+
+  fill(102);
+  rect(81, 81, 63, 63);
+
+  fill(204);
+  quad(189, 18, 216, 18, 216, 360, 144, 360);
+
+  fill(255);
+  ellipse(252, 144, 72, 72);
+
+  fill(204);
+  triangle(288, 18, 351, 360, 288, 360); 
+
+  fill(255);
+  arc(479, 300, 280, 280, PI, TWO_PI);
+}
+

--- a/sketching-doc/sketching-doc/manual-examples/basics/form/bezier.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/form/bezier.js
@@ -1,0 +1,23 @@
+/**
+ * Bezier. 
+ * 
+ * The first two parameters for the bezier() function specify the 
+ * first point in the curve and the last two parameters specify 
+ * the last point. The middle parameters set the control points
+ * that define the shape of the curve. 
+ */
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container"); 
+  stroke(255);
+  noFill();
+}
+
+function draw() {
+  background(0);
+  for (var i = 0; i < 200; i += 20) {
+    bezier(mouseX-(i/2.0), 40+i, 410, 20, 440, 300, 240-(i/16.0), 300+(i/8.0));
+  }
+}
+

--- a/sketching-doc/sketching-doc/manual-examples/basics/form/pie-chart.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/form/pie-chart.js
@@ -1,0 +1,31 @@
+/**
+ * Pie Chart  
+ * 
+ * Uses the arc() function to generate a pie chart from the data
+ * stored in an array. 
+ */
+
+var angles = [ 30, 10, 45, 35, 60, 38, 75, 67 ];
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  noStroke();
+  noLoop();  // Run once and stop
+}
+
+function draw() {
+  background(100);
+  pieChart(300, angles);
+}
+
+function pieChart(diameter, data) {
+  var lastAngle = 0;
+  for (var i = 0; i < data.length; i++) {
+    var gray = map(i, 0, data.length, 0, 255);
+    fill(gray);
+    arc(width/2, height/2, diameter, diameter, lastAngle, lastAngle+radians(angles[i]));
+    lastAngle += radians(angles[i]);
+  }
+}
+

--- a/sketching-doc/sketching-doc/manual-examples/basics/form/pie-chart.rkt
+++ b/sketching-doc/sketching-doc/manual-examples/basics/form/pie-chart.rkt
@@ -23,3 +23,4 @@
     (fill gray)
     (arc (* 1/2 width) (* 1/2 height) diameter diameter last-angle (+ last-angle (radians a)))
     (+= last-angle (radians a))))
+

--- a/sketching-doc/sketching-doc/manual-examples/basics/form/point-and-lines.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/form/point-and-lines.js
@@ -1,0 +1,37 @@
+/**
+ * Points and Lines. 
+ * 
+ * Points and lines can be used to draw basic geometry.
+ * Change the value of the variable d to scale the form.
+ * The four variables set the positions based on the value of d. 
+ */
+
+function setup() {
+  var d = 70;
+  var p1 = d;
+  var p2 = p1+d;
+  var p3 = p2+d;
+  var p4 = p3+d;
+
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  noSmooth();
+  background(0);
+  translate(140, 0);
+
+  // Draw gray box
+  stroke(153);
+  line(p3, p3, p2, p3);
+  line(p2, p3, p2, p2);
+  line(p2, p2, p3, p2);
+  line(p3, p2, p3, p3);
+
+  // Draw white points
+  stroke(255);
+  point(p1, p1);
+  point(p1, p3); 
+  point(p2, p4);
+  point(p3, p1); 
+  point(p4, p2);
+  point(p4, p4);
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/form/point-and-lines.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/form/point-and-lines.js
@@ -28,6 +28,7 @@ function setup() {
 
   // Draw white points
   stroke(255);
+  strokeWeight(4);
   point(p1, p1);
   point(p1, p3); 
   point(p2, p4);

--- a/sketching-doc/sketching-doc/manual-examples/basics/form/regular-polygons.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/form/regular-polygons.js
@@ -1,0 +1,47 @@
+/**
+ * Regular Polygon
+ * 
+ * What is your favorite? Pentagon? Hexagon? Heptagon? 
+ * No? What about the icosagon? The polygon() function 
+ * created for this example is capable of drawing any 
+ * regular polygon. Try placing different numbers into the 
+ * polygon() function calls within draw() to explore. 
+ */
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+}
+
+function draw() {
+  background(102);
+  
+  push();
+  translate(width*0.2, height*0.5);
+  rotate(frameCount / 200.0);
+  polygon(0, 0, 82, 3); 
+  pop();
+  
+  push();
+  translate(width*0.5, height*0.5);
+  rotate(frameCount / 50.0);
+  polygon(0, 0, 80, 20); 
+  pop();
+  
+  push();
+  translate(width*0.8, height*0.5);
+  rotate(frameCount / -100.0);
+  polygon(0, 0, 70, 7); 
+  pop();
+}
+
+function polygon(x, y, radius, npoints) {
+  var angle = TWO_PI / npoints;
+  beginShape();
+  for (var a = 0; a < TWO_PI; a += angle) {
+    var sx = x + cos(a) * radius;
+    var sy = y + sin(a) * radius;
+    vertex(sx, sy);
+  }
+  endShape(CLOSE);
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/form/star.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/form/star.js
@@ -1,0 +1,49 @@
+/**
+ * Star
+ * 
+ * The star() function created for this example is capable of drawing a
+ * wide range of different forms. Try placing different numbers into the 
+ * star() function calls within draw() to explore. 
+ */
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+}
+
+function draw() {
+  background(102);
+  
+  push();
+  translate(width*0.2, height*0.5);
+  rotate(frameCount / 200.0);
+  star(0, 0, 5, 70, 3); 
+  pop();
+  
+  push();
+  translate(width*0.5, height*0.5);
+  rotate(frameCount / 50.0);
+  star(0, 0, 80, 100, 40); 
+  pop();
+  
+  push();
+  translate(width*0.8, height*0.5);
+  rotate(frameCount / -100.0);
+  star(0, 0, 30, 70, 5); 
+  pop();
+}
+
+function star(x, y, radius1, radius2, npoints) {
+  var angle = TWO_PI / npoints;
+  var halfAngle = angle/2.0;
+  beginShape();
+  for (var a = 0; a < TWO_PI; a += angle) {
+    var sx = x + cos(a) * radius2;
+    var sy = y + sin(a) * radius2;
+    vertex(sx, sy);
+    sx = x + cos(a+halfAngle) * radius1;
+    sy = y + sin(a+halfAngle) * radius1;
+    vertex(sx, sy);
+  }
+  endShape(CLOSE);
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/form/triangle-strip.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/form/triangle-strip.js
@@ -1,0 +1,43 @@
+/**
+ * Triangle Strip 
+ * by Ira Greenberg. 
+ * 
+ * Generate a closed ring using the vertex() function and 
+ * beginShape(TRIANGLE_STRIP) mode. The outsideRadius and insideRadius 
+ * variables control ring s radii respectively.
+ */
+
+var x;
+var y;
+var outsideRadius = 150;
+var insideRadius = 100;
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  background(204);
+  x = width/2;
+  y = height/2;
+}
+
+function draw() {
+  background(204);
+  
+  var numPoints = int(map(mouseX, 0, width, 6, 60));
+  var angle = 0;
+  var angleStep = 180.0/numPoints;
+    
+  beginShape(TRIANGLE_STRIP); 
+  for (var i = 0; i <= numPoints; i++) {
+    var px = x + cos(radians(angle)) * outsideRadius;
+    var py = y + sin(radians(angle)) * outsideRadius;
+    angle += angleStep;
+    vertex(px, py);
+    px = x + cos(radians(angle)) * insideRadius;
+    py = y + sin(radians(angle)) * insideRadius;
+    vertex(px, py); 
+    angle += angleStep;
+  }
+  endShape();
+}
+

--- a/sketching-doc/sketching-doc/manual-examples/basics/input/clock.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/input/clock.js
@@ -1,0 +1,63 @@
+/**
+ * Clock. 
+ * 
+ * The current time can be read with the second(), minute(), 
+ * and hour() functions. In this example, sin() and cos() values
+ * are used to set the position of the hands.
+ */
+
+var cx, cy;
+var secondsRadius;
+var minutesRadius;
+var hoursRadius;
+var clockDiameter;
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  stroke(255);
+  
+  var radius = min(width, height) / 2;
+  secondsRadius = radius * 0.72;
+  minutesRadius = radius * 0.60;
+  hoursRadius = radius * 0.50;
+  clockDiameter = radius * 1.8;
+  
+  cx = width / 2;
+  cy = height / 2;
+}
+
+function draw() {
+  background(0);
+  
+  // Draw the clock background
+  fill(80);
+  noStroke();
+  ellipse(cx, cy, clockDiameter, clockDiameter);
+  
+  // Angles for sin() and cos() start at 3 o clock;
+  // subtract HALF_PI to make them start at the top
+  var s = map(second(), 0, 60, 0, TWO_PI) - HALF_PI;
+  var m = map(minute() + norm(second(), 0, 60), 0, 60, 0, TWO_PI) - HALF_PI; 
+  var h = map(hour() + norm(minute(), 0, 60), 0, 24, 0, TWO_PI * 2) - HALF_PI;
+  
+  // Draw the hands of the clock
+  stroke(255);
+  strokeWeight(1);
+  line(cx, cy, cx + cos(s) * secondsRadius, cy + sin(s) * secondsRadius);
+  strokeWeight(2);
+  line(cx, cy, cx + cos(m) * minutesRadius, cy + sin(m) * minutesRadius);
+  strokeWeight(4);
+  line(cx, cy, cx + cos(h) * hoursRadius, cy + sin(h) * hoursRadius);
+  
+  // Draw the minute ticks
+  strokeWeight(2);
+  beginShape(POINTS);
+  for (var a = 0; a < 360; a+=6) {
+    var angle = radians(a);
+    var x = cx + cos(angle) * secondsRadius;
+    var y = cy + sin(angle) * secondsRadius;
+    vertex(x, y);
+  }
+  endShape();
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/input/constrain.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/input/constrain.js
@@ -1,0 +1,39 @@
+/**
+ * Constrain. 
+ * 
+ * Move the mouse across the screen to move the circle. 
+ * The program constrains the circle to its box. 
+ */
+ 
+var mx = 0;
+var my = 0;
+var easing = 0.05;
+var radius = 24;
+var edge = 100;
+var inner = edge + radius;
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  noStroke(); 
+  ellipseMode(RADIUS);
+  rectMode(CORNERS);
+}
+
+function draw() { 
+  background(51);
+  
+  if (abs(mouseX - mx) > 0.1) {
+    mx = mx + (mouseX - mx) * easing;
+  }
+  if (abs(mouseY - my) > 0.1) {
+    my = my + (mouseY- my) * easing;
+  }
+  
+  mx = constrain(mx, inner, width - inner);
+  my = constrain(my, inner, height - inner);
+  fill(76);
+  rect(edge, edge, width-edge, height-edge);
+  fill(255);  
+  ellipse(mx, my, radius, radius);
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/input/easing.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/input/easing.js
@@ -1,0 +1,38 @@
+/**
+ * Easing. 
+ * 
+ * Move the mouse across the screen and the symbol will follow.  
+ * Between drawing each frame of the animation, the program
+ * calculates the difference between the position of the 
+ * symbol and the cursor. If the distance is larger than
+ * 1 pixel, the symbol moves part of the distance (0.05) from its
+ * current position toward the cursor. 
+ */
+ 
+var x = 0;
+var y = 0;
+var easing = 0.05;
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container"); 
+  noStroke();  
+}
+
+function draw() { 
+  background(51);
+  
+  var targetX = mouseX;
+  var dx = targetX - x;
+  if(abs(dx) > 1) {
+    x += dx * easing;
+  }
+  
+  var targetY = mouseY;
+  var dy = targetY - y;
+  if(abs(dy) > 1) {
+    y += dy * easing;
+  }
+  
+  ellipse(x, y, 66, 66);
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/input/keyboard-functions.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/input/keyboard-functions.js
@@ -1,0 +1,96 @@
+// /**
+//  * Keyboard Functions. 
+//  * Modified from code by Martin. 
+//  * Original "Color Typewriter" concept by John Maeda. 
+//  * 
+//  * Click on the window to give it focus and press the letter keys to type colors. 
+//  * The keyboard function keyPressed() is called whenever
+//  * a key is pressed. keyReleased() is another keyboard
+//  * function that is called when a key is released.
+//  */
+ 
+var maxHeight = 40;
+var minHeight = 20;
+var letterHeight = maxHeight; // Height of the letters
+var letterWidth = 20;          // Width of the letter
+
+var x = -letterWidth;          // X position of the letters
+var y = 0;                      // Y position of the letters
+
+var newletter;              
+
+var numChars = 26;      // There are 26 characters in the alphabet
+var colors = [];
+
+function setup()
+{
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  noStroke();
+  colorMode(HSB, numChars);
+  background(numChars/2);
+  // Set a gray value for each key
+  for(var i = 0; i < numChars; i++) {
+    colors[i] = color(i, numChars, numChars);    
+  }
+
+}
+
+function draw()
+{
+  if(newletter == true) {
+    // Draw the "letter"
+    var y_pos;
+    if (letterHeight == maxHeight) {
+      y_pos = y;
+      rect( x, y_pos, letterWidth, letterHeight );
+    } else {
+      y_pos = y + minHeight;
+      rect( x, y_pos, letterWidth, letterHeight );
+      fill(numChars/2);
+      rect( x, y_pos-minHeight, letterWidth, letterHeight );
+    }
+    console.log(letterWidth,letterHeight);
+    newletter = false;
+    println(letterWidth,letterHeight);
+
+  }
+}
+
+function keyTyped() {
+  console.log(key);
+  var keyVal = key.charCodeAt(0);
+  println(keyVal);
+  // If the key is between "A"(65) to "Z" and "a" to "z"(122)
+  if((keyVal >= "A".charCodeAt(0) && keyVal <= "Z".charCodeAt(0)) || (keyVal >= "a".charCodeAt(0) && keyVal <= "z".charCodeAt(0))) {
+    var keyIndex = 0;
+    if(keyVal <= "Z".charCodeAt(0)) {
+      keyIndex = keyVal-"A".charCodeAt(0);
+      letterHeight = maxHeight;
+      fill(colors[keyVal-"A".charCodeAt(0)]);
+    } else {
+      keyIndex = keyVal-"a".charCodeAt(0);
+      letterHeight = minHeight;
+      fill(colors[keyVal-"a".charCodeAt(0)]);
+    }
+  } else {
+    fill(0);
+    letterHeight = 10;
+  }
+
+  newletter = true;
+
+  // Update the "letter" position
+  x = ( x + letterWidth ); 
+
+  // Wrap horizontally
+  if (x > width - letterWidth) {
+    x = 0;
+    y+= maxHeight;
+  }
+
+  // Wrap vertically
+  if( y > height - letterHeight) {
+    y = 0;      // reset y to 0
+  }
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/input/keyboard.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/input/keyboard.js
@@ -1,0 +1,40 @@
+/**
+ * Keyboard. 
+ * 
+ * Click on the image to give it focus and press the letter keys 
+ * to create forms in time and space. Each key has a unique identifying 
+ * number. These numbers can be used to position shapes in space. 
+ */
+
+var rectWidth;
+   
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  noStroke();
+  background(0);
+  rectWidth = width/4;
+}
+
+function draw() { 
+  // keep draw() here to continue looping while waiting for keys
+}
+
+function keyPressed() {
+  var keyIndex = -1;
+  var keyVal = key.charCodeAt(0);
+  if (keyVal >= "A".charCodeAt(0) && keyVal <= "Z".charCodeAt(0)) {
+    keyIndex = keyVal - "A".charCodeAt(0);
+  } else if (keyVal >= "a".charCodeAt(0) && keyVal <= "z".charCodeAt(0)) {
+    keyIndex = keyVal - "a".charCodeAt(0);
+  }
+  if (keyIndex === -1) {
+    // If it is not a letter key, clear the screen
+    background(0);
+  } else { 
+    // It is a letter key, fill a rectangle
+    fill(millis() % 255);
+    var x = map(keyIndex, 0, 25, 0, width - rectWidth);
+    rect(x, 0, rectWidth, height);
+  }
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/input/milliseconds.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/input/milliseconds.js
@@ -1,0 +1,25 @@
+/**
+ * Milliseconds. 
+ * 
+ * A millisecond is 1/1000 of a second. 
+ * Processing keeps track of the number of milliseconds a program has run.
+ * By modifying this number with the modulo(%) operator, 
+ * different patterns in time are created.  
+ */
+ 
+var scale;
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  noStroke();
+  scale = width/20;
+}
+
+function draw() { 
+  for (var i = 0; i < scale; i++) {
+    colorMode(RGB, (i+1) * scale * 10);
+    fill(millis()%((i+1) * scale * 10));
+    rect(i*scale, 0, scale, height);
+  }
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/input/mouse-1d.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/input/mouse-1d.js
@@ -1,0 +1,30 @@
+/**
+ * Mouse 1D. 
+ * 
+ * Move the mouse left and right to shift the balance. 
+ * The "mouseX" variable is used to control both the 
+ * size and color of the rectangles. 
+ */
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  noStroke();
+  colorMode(RGB, height, height, height);
+  rectMode(CENTER);
+}
+
+function draw() {
+  background(0.0);
+
+  var r1 = map(mouseX, 0, width, 0, height);
+  var r2 = height-r1;
+  
+  fill(r1);
+  rect(width/2 + r1/2, height/2, r1, r1);
+  
+  fill(r2);
+  rect(width/2 - r2/2, height/2, r2, r2);
+
+}
+

--- a/sketching-doc/sketching-doc/manual-examples/basics/input/mouse-2d.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/input/mouse-2d.js
@@ -1,0 +1,25 @@
+/**
+ * Mouse 2D. 
+ * 
+ * Moving the mouse changes the position and size of each box. 
+ */
+ 
+function setup() 
+{
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container"); 
+  noStroke();
+  rectMode(CENTER);
+}
+
+function draw() 
+{   
+  background(51); 
+  fill(255, 204);
+  rect(mouseX, height/2, mouseY/2+10, mouseY/2+10);
+  fill(255, 204);
+  var inverseX = width-mouseX;
+  var inverseY = height-mouseY;
+  rect(inverseX, height/2, (inverseY/2)+10, (inverseY/2)+10);
+}
+

--- a/sketching-doc/sketching-doc/manual-examples/basics/input/mouse-functions.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/input/mouse-functions.js
@@ -1,0 +1,68 @@
+/**
+ * Mouse Functions. 
+ * 
+ * Click on the box and drag it across the screen. 
+ */
+ 
+var bx;
+var by;
+var boxSize = 75;
+var overBox = false;
+var locked = false;
+var xOffset = 0.0; 
+var yOffset = 0.0; 
+
+function setup() 
+{
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  bx = width/2.0;
+  by = height/2.0;
+  rectMode(RADIUS);  
+}
+
+function draw() 
+{ 
+  background(0);
+  
+  // Test if the cursor is over the box 
+  if (mouseX > bx-boxSize && mouseX < bx+boxSize && 
+      mouseY > by-boxSize && mouseY < by+boxSize) {
+    overBox = true;  
+    if(!locked) { 
+      stroke(255); 
+      fill(153);
+    } 
+  } else {
+    stroke(153);
+    fill(153);
+    overBox = false;
+  }
+  
+  // Draw the box
+  rect(bx, by, boxSize, boxSize);
+}
+
+function mousePressed() {
+  if(overBox) { 
+    locked = true; 
+    fill(255, 255, 255);
+  } else {
+    locked = false;
+  }
+  xOffset = mouseX-bx; 
+  yOffset = mouseY-by; 
+
+}
+
+function mouseDragged() {
+  if(locked) {
+    bx = mouseX-xOffset; 
+    by = mouseY-yOffset; 
+  }
+}
+
+function mouseReleased() {
+  locked = false;
+}
+

--- a/sketching-doc/sketching-doc/manual-examples/basics/input/mouse-press.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/input/mouse-press.js
@@ -1,0 +1,25 @@
+/**
+ * Mouse Press. 
+ * 
+ * Move the mouse to position the shape. 
+ * Press the mouse button to invert the color. 
+ */
+
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  noSmooth();
+  fill(126);
+  background(102);
+}
+
+function draw() {
+  if (mouseIsPressed) {
+    stroke(255);
+  } else {
+    stroke(0);
+  }
+  line(mouseX-66, mouseY, mouseX+66, mouseY);
+  line(mouseX, mouseY-66, mouseX, mouseY+66); 
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/input/mouse-signals.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/input/mouse-signals.js
@@ -1,0 +1,60 @@
+/**
+ * Mouse Signals. 
+ * 
+ * Move and click the mouse to generate signals. 
+ * The top row is the signal from "mouseX", 
+ * the middle row is the signal from "mouseY",
+ * and the bottom row is the signal from "mousePressed". 
+ */
+ 
+var xvals;
+var yvals;
+var bvals;
+
+function setup() 
+{
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  noSmooth();
+  xvals = [];
+  yvals = [];
+  bvals = [];
+  for (var i = 0; i < width; i++) {
+    xvals[i] = 0;
+    yvals[i] = 0;
+    bvals[i] = 0;
+  }
+}
+
+var arrayindex = 0;
+
+function draw() {
+  background(102);
+  
+  for(var i = 1; i < width; i++) { 
+    xvals[i-1] = xvals[i]; 
+    yvals[i-1] = yvals[i];
+    bvals[i-1] = bvals[i];
+  } 
+  // Add the new values to the end of the array 
+  xvals[width-1] = mouseX; 
+  yvals[width-1] = mouseY;
+  if(mouseIsPressed) {
+    bvals[width-1] = 0;
+  } else {
+    bvals[width-1] = 255;
+  }
+  
+  fill(255);
+  noStroke();
+  rect(0, height/3, width, height/3+1);
+
+  for(var i=1; i<width; i++) {
+    stroke(255);
+    point(i, map(xvals[i], 0, width, 0, height/3-1));
+    stroke(0);
+    point(i, height/3+yvals[i]/3);
+    stroke(255);
+    line(i, (2*height/3) + bvals[i], i, (2*height/3) + bvals[i-1]);
+  }
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/input/storing-input.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/input/storing-input.js
@@ -1,0 +1,50 @@
+// This needs to be resolved
+// https://github.com/lmccart/p5.js/issues/406
+
+// /**
+//  * Storing Input. 
+//  * 
+//  * Move the mouse across the screen to change the position
+//  * of the circles. The positions of the mouse are recorded
+//  * into an array and played back every frame. Between each
+//  * frame, the newest value are added to the end of each array
+//  * and the oldest value is deleted. 
+//  */
+ 
+var num = 60;
+var mx = [];
+var my = [];
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  noStroke();
+  fill(255, 153); 
+  for (var i = 0; i < num; i++) {
+    mx[i] = 0;
+    my[i] = 0; 
+  }
+}
+
+var prev = 0;
+
+function draw() {
+  background(51); 
+
+  var diff = frameCount - prev;
+  
+  // Cycle through the array, using a different entry on each frame. 
+  // Using modulo (%) like this is faster than moving all the values over.
+  var which = frameCount % num;
+  mx[which] = mouseX;
+  my[which] = mouseY;
+  
+  var count = 0;
+  for (var i = 0; i < num; i++) {
+    // which+1 is the smallest (the oldest in the array)
+    var index = (which + 1 + i) % num;
+    ellipse(mx[index], my[index], i, i);
+  }
+  
+  prev = frameCount;
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/objects/composite-objects.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/objects/composite-objects.js
@@ -1,0 +1,23 @@
+/**
+ * Composite Objects
+ * 
+ * An object can include several other objects. Creating such composite objects 
+ * is a good way to use the principles of modularity and build higher levels of 
+ * abstraction within a program.
+ */
+
+var er1, er2;
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  er1 = new EggRing(width*0.45, height*0.5, 0.1, 120);
+  er2 = new EggRing(width*0.65, height*0.8, 0.05, 180);
+}
+
+
+function draw() {
+  background(0);
+  er1.transmit();
+  er2.transmit();
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/objects/egg-ring.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/objects/egg-ring.js
@@ -1,0 +1,16 @@
+
+function EggRing(x,  y,  t,  sp) {
+  this.ovoid = new Egg(x, y, t, sp);
+  this.circle = new Ring();
+  this.circle.start(x, y - sp/2);
+  
+  this.transmit = function() {
+    this.ovoid.wobble();
+    this.ovoid.display();
+    this.circle.grow();
+    this.circle.display();
+    if (this.circle.on == false) {
+      this.circle.on = true;
+    }
+  }
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/objects/egg.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/objects/egg.js
@@ -1,0 +1,30 @@
+// Constructor
+function Egg(xpos, ypos, t, s) {
+  this.x = xpos;
+  this.y = ypos;
+  this.tilt = t;
+  this.scalar = s / 100.0;
+  this.angle = 0;
+
+  this.wobble = function() {
+    this.tilt = cos(this.angle) / 8;
+    this.angle += 0.1;
+  }
+
+  this.display = function() {
+    noStroke();
+    fill(255);
+    push();
+    translate(this.x, this.y);
+    rotate(this.tilt);
+    scale(this.scalar);
+    beginShape();
+    vertex(0, -100);
+    bezierVertex(25, -100, 40, -65, 40, -40);
+    bezierVertex(40, -15, 25, 0, 0, 0);
+    bezierVertex(-25, 0, -40, -15, -40, -40);
+    bezierVertex(-40, -65, -25, -100, 0, -100);
+    endShape();
+    pop();
+  }
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/objects/inheritance.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/objects/inheritance.js
@@ -1,0 +1,81 @@
+/**
+ * Inheritance
+ * 
+ * A class can be defined using another class as a foundation. In object-oriented
+ * programming terminology, one class can inherit fi elds and methods from another. 
+ * An object that inherits from another is called a subclass, and the object it 
+ * inherits from is called a superclass. A subclass extends the superclass.
+ */
+
+var spots;
+var arm;
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  arm = new SpinArm(width/2, height/2, 0.01);
+  spots = new SpinSpots(width/2, height/2, -0.02, 90.0);
+}
+
+function draw() {
+  background(204);
+  arm.update();
+  arm.display();
+  spots.update();
+  spots.display();
+}
+
+
+function Spin(xpos, ypos, s) {
+  this.x = xpos;
+  this.y = ypos;
+  this.speed = s;
+  this.angle = 0;
+  
+  this.update = function() {
+    this.angle += this.speed;
+  }
+}
+
+// Child class constructor
+function SpinArm(x, y, s) {
+  Spin.call(this, x, y, s);
+
+  // Override the display method
+  this.display = function(){
+    strokeWeight(1);
+    stroke(0);
+    push();
+    translate(this.x, this.y);
+    this.angle += this.speed;
+    rotate(this.angle);
+    line(0, 0, 165, 0);
+    pop();
+  };
+};
+
+// Inherit from the parent class
+SpinArm.prototype = Object.create(Spin.prototype);
+this.constructor = SpinArm;
+
+// Child class constructor
+function SpinSpots(x, y, s, d) {
+  this.dim = d;
+  Spin.call(this, x, y, s);
+
+  // Override the display method
+  this.display = function(){
+    noStroke();
+    push();
+    translate(this.x, this.y);
+    this.angle += this.speed;
+    rotate(this.angle);
+    ellipse(-this.dim/2, 0, this.dim, this.dim);
+    ellipse(this.dim/2, 0, this.dim, this.dim);
+    pop();
+  };
+};
+
+// Inherit from the parent class
+SpinSpots.prototype = Object.create(Spin.prototype);
+this.constructor = SpinSpots;

--- a/sketching-doc/sketching-doc/manual-examples/basics/objects/inheritance.rkt
+++ b/sketching-doc/sketching-doc/manual-examples/basics/objects/inheritance.rkt
@@ -1,5 +1,4 @@
 #lang sketching
-
 ;;;
 ;;; Inheritance
 ;;;
@@ -69,7 +68,3 @@
   (arm.display)
   (spots.update)
   (spots.display))
-
-
-
-

--- a/sketching-doc/sketching-doc/manual-examples/basics/objects/multiple-constructors.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/objects/multiple-constructors.js
@@ -1,0 +1,41 @@
+/**
+ * Multiple constructors
+ * 
+ * A class can have multiple constructors that assign the fields in different ways. 
+ * Sometimes it iss beneficial to specify every aspect of an object s data by assigning 
+ * parameters to the fields, but other times it might be appropriate to define only 
+ * one or a few.
+ */
+
+var sp1, sp2;
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  background(204);
+  noLoop();
+  // Run the constructor without parameters
+  sp1 = new Spot();
+  // Run the constructor with three parameters
+  sp2 = new Spot(width*0.5, height*0.5, 120);
+}
+
+function draw() {
+  sp1.display();
+  sp2.display();
+} 
+
+// First version of the Spot constructor;
+// the fields are assigned default values
+// Second version of the Spot constructor;
+// the fields are assigned with parameters
+function Spot(xpos, ypos, r) {
+  this.radius = r || 40;
+  this.x = xpos || width*0.25;
+  this.y = ypos || height*0.5;
+  
+  this.display = function() {
+    ellipse(this.x, this.y, this.radius*2, this.radius*2);
+  }
+  
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/objects/multiple-constructors.rkt
+++ b/sketching-doc/sketching-doc/manual-examples/basics/objects/multiple-constructors.rkt
@@ -1,11 +1,13 @@
 #lang sketching
-
 ;; Multiple constructors
 
-;; A class can have multiple constructors that assign the fields in different ways.
-;; Sometimes it's beneficial to specify every aspect of an object's data by
-;; assigning values to the fields, but other times it might be appropriate to define only one or a few.
+;; Original text:
+;;   A class can have multiple constructors that assign the fields in different ways.
+;;   Sometimes it's beneficial to specify every aspect of an object's data by
+;;   assigning values to the fields, but other times it might be appropriate to define only one or a few.
 
+;; Sketching:
+;;    We use init fields with default values instead of explicit constructors.
 
 ;;;
 ;;; Spot
@@ -15,11 +17,10 @@
   (init-field
    [x      (* width 0.25)]
    [y      (* height 0.5)]
-   [radius 40])
-  
-  ; "constructor"  
+   [radius 40])  
+  ; "Constructor"  
   (super-new)
-  
+  ; Methods
   (define/public (display)    
     (ellipse x y (* radius 2) (* radius 2))))
 
@@ -36,10 +37,8 @@
   (no-loop)
   ;; Run the constructor without parameters
   (:= sp1 (make-object Spot))
-  #;(displayln sp1)
   ;; Run the constructor with three parameters
-  (:= sp2 (make-object Spot (* width 0.5) (* height 0.5) 120))
-  #;(displayln sp2))
+  (:= sp2 (make-object Spot (* width 0.5) (* height 0.5) 120)))
 
 (define (draw)
   (sp1.display)

--- a/sketching-doc/sketching-doc/manual-examples/basics/objects/objects.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/objects/objects.js
@@ -1,0 +1,64 @@
+/**
+ * Objects
+ * by hbarragan. 
+ * 
+ * Move the cursor across the image to change the speed and positions
+ * of the geometry. The class MRect defines a group of lines.
+ */
+
+var r1, r2, r3, r4;
+ 
+function setup()
+{
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  fill(255, 204);
+  noStroke();
+  r1 = new MRect(1, 134.0, 0.532, 0.1*height, 10.0, 60.0);
+  r2 = new MRect(2, 44.0, 0.166, 0.3*height, 5.0, 50.0);
+  r3 = new MRect(2, 58.0, 0.332, 0.4*height, 10.0, 35.0);
+  r4 = new MRect(1, 120.0, 0.0498, 0.9*height, 15.0, 60.0);
+}
+ 
+function draw()
+{
+  background(0);
+  
+  r1.display();
+  r2.display();
+  r3.display();
+  r4.display();
+ 
+  r1.move(mouseX-(width/2), mouseY+(height*0.1), 30);
+  r2.move((mouseX+(width*0.05))%width, mouseY+(height*0.025), 20);
+  r3.move(mouseX/4, mouseY-(height*0.025), 40);
+  r4.move(mouseX-(width/2), (height-mouseY), 50);
+}
+ 
+
+function MRect(iw, ixp, ih, iyp, id, it) {
+  this.w = iw; // single bar width
+  this.xpos = ixp; // rect xposition
+  this.h = ih; // rect height
+  this.ypos = iyp; // rect yposition
+  this.d = id; // single bar distance
+  this.t = it; // number of bars
+ 
+ 
+  this.move = function(posX, posY, damping) {
+    var dif = this.ypos - posY;
+    if (abs(dif) > 1) {
+      this.ypos -= dif/damping;
+    }
+    dif = this.xpos - posX;
+    if (abs(dif) > 1) {
+      this.xpos -= dif/damping;
+    }
+  }
+ 
+  this.display = function() {
+    for (var i=0; i<this.t; i++) {
+      rect(this.xpos+(i*(this.d+this.w)), this.ypos, this.w, height*this.h);
+    }
+  }
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/objects/ring.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/objects/ring.js
@@ -1,0 +1,32 @@
+function Ring() {
+
+  this.x = 0;
+  this.y = 0;
+  this.on = false;
+  this.diameter = 0;
+
+  this.start = function(xpos,  ypos) {
+    this.x = xpos;
+    this.y = ypos;
+    this.on = true;
+    this.diameter = 1;
+  }
+  
+  this.grow = function() {
+    if (this.on == true) {
+      this.diameter += 0.5;
+      if (this.diameter > width*2) {
+        this.diameter = 0.0;
+      }
+    }
+  }
+  
+  this.display = function() {
+    if (this.on == true) {
+      noFill();
+      strokeWeight(4);
+      stroke(155, 153);
+      ellipse(this.x, this.y, this.diameter, this.diameter);
+    }
+  }
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/transform/arm.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/transform/arm.js
@@ -1,0 +1,41 @@
+/**
+ * Arm. 
+ * 
+ * The angle of each segment is controlled with the mouseX and
+ * mouseY position. The transformations applied to the first segment
+ * are also applied to the second segment because they are inside
+ * the same push() and pop() group.
+*/
+
+var x, y;
+var angle1 = 0.0;
+var angle2 = 0.0;
+var segLength = 100;
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  strokeWeight(30);
+  stroke(255, 160);
+  
+  x = width * 0.3;
+  y = height * 0.5;
+}
+
+function draw() {
+  background(0);
+  
+  angle1 = (mouseX/float(width) - 0.5) * -PI;
+  angle2 = (mouseY/float(height) - 0.5) * PI;
+  
+  push();
+  segment(x, y, angle1); 
+  segment(segLength, 0, angle2);
+  pop();
+}
+
+function segment(x, y, a) {
+  translate(x, y);
+  rotate(a);
+  line(0, 0, segLength, 0);
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/transform/rotate.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/transform/rotate.js
@@ -1,0 +1,35 @@
+/**
+ * Rotate. 
+ * 
+ * Rotating a square around the Z axis. To get the results
+ * you expect, send the rotate function angle parameters that are
+ * values between 0 and PI*2 (TWO_PI which is roughly 6.28). If you prefer to 
+ * think about angles as degrees (0-360), you can use the radians() 
+ * method to convert your values. For example: scale(radians(90))
+ * is identical to the statement scale(PI/2). 
+ */
+
+var angle = 0;
+var jitter = 0;
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  noStroke();
+  fill(255);
+  rectMode(CENTER);
+}
+
+function draw() {
+  background(51);
+
+  // during even-numbered seconds (0, 2, 4, 6...)
+  if (second() % 2 == 0) {  
+    jitter = random(-0.1, 0.1);
+  }
+  angle = angle + jitter;
+  var c = cos(angle);
+  translate(width/2, height/2);
+  rotate(c);
+  rect(0, 0, 180, 180);   
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/transform/scale.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/transform/scale.js
@@ -1,0 +1,38 @@
+/**
+ * Scale 
+ * by Denis Grutze. 
+ * 
+ * Paramenters for the scale() function are values specified 
+ * as decimal percentages. For example, the method call scale(2.0) 
+ * will increase the dimension of the shape by 200 percent. 
+ * Objects always scale from the origin. 
+ */
+ 
+var a = 0.0;
+var s = 0.0;
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  noStroke();
+  rectMode(CENTER);
+  frameRate(30);
+}
+
+function draw() {
+  
+  background(102);
+  
+  a = a + 0.04;
+  s = cos(a)*2;
+  
+  translate(width/2, height/2);
+  scale(s); 
+  fill(51);
+  rect(0, 0, 50, 50); 
+  
+  translate(75, 0);
+  fill(255);
+  scale(s);
+  rect(0, 0, 50, 50);       
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/transform/translate.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/transform/translate.js
@@ -1,0 +1,38 @@
+/**
+ * Translate. 
+ * 
+ * The translate() function allows objects to be moved
+ * to any location within the window. The first parameter
+ * sets the x-axis offset and the second parameter sets the
+ * y-axis offset. 
+ */
+ 
+var x = 0;
+var dim = 80.0;
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  noStroke();
+}
+
+function draw() {
+  background(102);
+  
+  x = x + 0.8;
+  
+  if (x > width + dim) {
+    x = -dim;
+  } 
+  
+  translate(x, height/2-dim/2);
+  fill(255);
+  rect(-dim/2, -dim/2, dim, dim);
+  
+  // Transforms accumulate. Notice how this rect moves 
+  // twice as fast as the other, but it has the same 
+  // parameter for the x-axis value
+  translate(x, dim);
+  fill(0);
+  rect(-dim/2, -dim/2, dim, dim);
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/typography/letters.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/typography/letters.js
@@ -1,0 +1,54 @@
+/**
+ * Letters. 
+ * 
+ * Draws letters to the screen. This requires loading a font, 
+ * setting the font, and then drawing the letters.
+ */
+
+var f;
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  background(0);
+
+  // Create the font
+  //printArray(PFont.list());
+  textFont("Source Code Pro", 24);
+  textAlign(CENTER, CENTER);
+} 
+
+function draw() {
+  background(0);
+
+  // Set the left and top margin
+  var margin = 10;
+  translate(margin*4, margin*4);
+
+  var gap = 46;
+  var counter = 35;
+  
+  for (var y = 0; y < height-gap; y += gap) {
+    for (var x = 0; x < width-gap; x += gap) {
+      
+      // See: https://github.com/processing/p5.js/issues/560
+      var letter = String.fromCharCode(counter);//char(counter);
+      
+      if (letter == "A" || letter == "E" || letter == "I" || letter == "O" || letter == "U") {
+        fill(255, 204, 0);
+      } 
+      else {
+        fill(255);
+      }
+      noStroke();
+
+      // Draw the letter to the screen
+      text(letter, x, y);
+
+      // Increment the counter
+      counter++;
+    }
+  }
+  noLoop();
+}
+

--- a/sketching-doc/sketching-doc/manual-examples/basics/typography/text-rotation.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/typography/text-rotation.js
@@ -1,0 +1,65 @@
+/**
+ * Text Rotation. 
+ * 
+ * Draws letters to the screen and rotates them at different angles.
+ */
+
+var f;
+var angleRotate = 0.0;
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  background(0);
+
+  // Create the font from the .ttf file in the data folder
+  textFont("Source Code Pro", 18);
+} 
+
+function draw() {
+  background(0);
+
+
+  push();
+  var angle1 = radians(45);
+  translate(100, 180);
+  rotate(angle1);
+  noStroke();
+  fill(255);
+  text("45 DEGREES", 0, 0);
+  strokeWeight(1);
+  stroke(153);
+  line(0, 0, 150, 0);
+  pop();
+
+  push();
+  var angle2 = radians(270);
+  translate(200, 180);
+  rotate(angle2);
+  noStroke();
+  fill(255);
+  text("270 DEGREES", 0, 0);
+  strokeWeight(1);
+  stroke(153);
+  line(0, 0, 150, 0);
+  pop();
+  
+  push();
+  translate(440, 180);
+  rotate(radians(angleRotate));
+  noStroke();
+  fill(255);
+  text(int(angleRotate) % 360 + " DEGREES", 0, 0);
+  strokeWeight(1);
+  stroke(153);
+  line(0, 0, 150, 0);
+  pop();
+  
+  angleRotate += 0.25;
+
+  stroke(255, 0, 0);
+  strokeWeight(4);
+  point(100, 180);
+  point(200, 180);
+  point(440, 180);
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/typography/words.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/typography/words.js
@@ -1,0 +1,44 @@
+/**
+ * Words. 
+ * 
+ * The text() function is used for writing words to the screen.
+ * The letters can be aligned left, center, or right with the 
+ * textAlign() function. 
+ */
+  
+var f;
+  
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  
+  // Create the font
+  //printArray(PFont.list());
+  //f = "Georgia";
+  textFont("Source Code Pro", 24);
+}
+
+function draw() {
+  background(102);
+  noStroke();
+  fill(255);
+  textAlign(RIGHT);
+  drawType(width * 0.25);
+  textAlign(CENTER);
+  drawType(width * 0.5);
+  textAlign(LEFT);
+  drawType(width * 0.75);
+}
+
+function drawType(x) {
+  line(x, 0, x, 65);
+  line(x, 220, x, height);
+  fill(0);
+  text("ichi", x, 95);
+  fill(51);
+  text("ni", x, 130);
+  fill(204);
+  text("san", x, 165);
+  fill(255);
+  text("shi", x, 210);
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/vectors/vector-2d.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/vectors/vector-2d.js
@@ -1,0 +1,45 @@
+/**
+ * Array 2D. 
+ * 
+ * Demonstrates the syntax for creating a two-dimensional (2D) array.
+ * Values in a 2D array are accessed through two index values.  
+ * 2D arrays are useful for storing images. In this example, each dot 
+ * is colored in relation to its distance from the center of the image. 
+ */
+
+var distances;
+var maxDistance;
+var spacer;
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  maxDistance = dist(width/2, height/2, width, height);
+  distances = [];
+  for (var x = 0; x < width; x++) {
+    distances[x] = [];
+    for (var y = 0; y < height; y++) {
+      var distance = dist(width/2, height/2, x, y);
+      distances[x][y] = distance/maxDistance * 255;
+    }
+  }
+  spacer = 10;
+  noLoop();  // Run once and stop
+}
+
+function draw() {
+  background(0);
+  // This embedded loop skips over values in the arrays based on
+  // the spacer variable, so there are more values in the array
+  // than are drawn here. Change the value of the spacer variable
+  // to change the density of the points
+  for (var y = 0; y < height; y += spacer) {
+    for (var x = 0; x < width; x += spacer) {
+      stroke(distances[x][y]);
+      point(x + spacer/2, y + spacer/2);
+    }
+  }
+}
+
+
+

--- a/sketching-doc/sketching-doc/manual-examples/basics/vectors/vector-of-objects-module.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/vectors/vector-of-objects-module.js
@@ -1,0 +1,32 @@
+
+  // Contructor
+function Module(xOffsetTemp, yOffsetTemp, xTemp, yTemp, speedTemp, tempUnit) {
+  this.xOffset = xOffsetTemp;
+  this.yOffset = yOffsetTemp;
+  this.x = xTemp;
+  this.y = yTemp;
+  this.speed = speedTemp;
+  this.unit = tempUnit;
+  this.xDirection = 1;
+  this.yDirection = 1;
+
+  // Custom method for updating the variables
+  this.update = function() {
+    this.x = this.x + (this.speed * this.xDirection);
+    if (this.x >= this.unit || this.x <= 0) {
+      this.xDirection *= -1;
+      this.x = this.x + (1 * this.xDirection);
+      this.y = this.y + (1 * this.yDirection);
+    }
+    if (this.y >= this.unit || this.y <= 0) {
+      this.yDirection *= -1;
+      this.y = this.y + (1 * this.yDirection);
+    }
+  }
+  
+  // Custom method for drawing the object
+  this.draw = function() {
+    fill(255);
+    ellipse(this.xOffset + this.x, this.yOffset + this.y, 6, 6);
+  }
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/vectors/vector-of-objects.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/vectors/vector-of-objects.js
@@ -1,0 +1,35 @@
+/**
+ * Array Objects. 
+ * 
+ * Demonstrates the syntax for creating an array of custom objects. 
+ */
+
+var unit = 40;
+var count;
+var mods;
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  noStroke();
+  var wideCount = width / unit;
+  var highCount = height / unit;
+  count = wideCount * highCount;
+  mods = [];
+
+  var index = 0;
+  for (var y = 0; y < highCount; y++) {
+    for (var x = 0; x < wideCount; x++) {
+      mods[index++] = new Module(x*unit, y*unit, unit/2, unit/2, random(0.05, 0.8), unit);
+    }
+  }
+}
+
+function draw() {
+  background(0);
+  for (var i = 0; i < mods.length; i++) {
+    var mod = mods[i];
+    mod.update();
+    mod.draw();
+  }
+}

--- a/sketching-doc/sketching-doc/manual-examples/basics/vectors/vector.js
+++ b/sketching-doc/sketching-doc/manual-examples/basics/vectors/vector.js
@@ -1,0 +1,51 @@
+/**
+ * Array. 
+ * 
+ * An array is a list of data. Each piece of data in an array 
+ * is identified by an index number representing its position in 
+ * the array. Arrays are zero based, which means that the first 
+ * element in the array is [0], the second element is [1], and so on. 
+ * In this example, an array named "coswav" is created and
+ * filled with the cosine values. This data is displayed three 
+ * separate ways on the screen. 
+ */
+
+var coswave; 
+
+function setup() {
+  var canvas = createCanvas(640, 360);
+  canvas.parent("p5container");
+  coswave = [];
+  for (var i = 0; i < width; i++) {
+    var amount = map(i, 0, width, 0, PI);
+    coswave[i] = abs(cos(amount));
+  }
+  background(255);
+  noLoop();
+}
+
+function draw() {
+
+  var y1 = 0;
+  var y2 = height/3;
+  for (var i = 0; i < width; i+=2) {
+    stroke(coswave[i]*255);
+    line(i, y1, i, y2);
+  }
+
+  y1 = y2;
+  y2 = y1 + y1;
+  for (var i = 0; i < width; i+=2) {
+    stroke(coswave[i]*255 / 4);
+    line(i, y1, i, y2);
+  }
+  
+  y1 = y2;
+  y2 = height;
+  for (var i = 0; i < width; i+=2) {
+    stroke(255 - coswave[i]*255);
+    line(i, y1, i, y2);
+  }
+  
+}
+

--- a/sketching-doc/sketching-doc/manual-sketching.scrbl
+++ b/sketching-doc/sketching-doc/manual-sketching.scrbl
@@ -101,7 +101,7 @@
         ;       page, we need to embed the sketches in iframes. The alternative is to rewrite all the
         ;       sketches.
         (cdata #f #f (string-append 
-                      "<iframe width='640' height='360' srcdoc='<html><head>"
+                      "<iframe frameBorder='0' width='640' height='360' srcdoc='<html><head>"
                       "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.4/p5.min.js\"></script>"
                       "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.4/addons/p5.dom.min.js\"></script>"
                       "</head>"
@@ -7251,13 +7251,16 @@ The examples using vectors are:
 @local-table-of-contents[#:style 'immediate-only]
 
 @subsubsection[#:tag "example_vectors"]{Vectors}
-@(example-from-file "basics/vectors/vector.rkt")
+@(p5example-from-file "basics/vectors/vector.js")
+@(example-from-file   "basics/vectors/vector.rkt")
 
 @subsubsection[#:tag "example_vector_2d"]{Vector 2d}
-@(example-from-file "basics/vectors/vector-2d.rkt")
+@(p5example-from-file "basics/vectors/vector-2d.js")
+@(example-from-file   "basics/vectors/vector-2d.rkt")
 
 @subsubsection[#:tag "example_vector_of_objects"]{Vector of objects}
-@(example-from-file "basics/vectors/vector-of-objects.rkt")
+@(p5example-from-file "basics/vectors/vector-of-objects.js" "basics/vectors/vector-of-objects-module.js")
+@(example-from-file   "basics/vectors/vector-of-objects.rkt")
 
 
 

--- a/sketching-doc/sketching-doc/manual-sketching.scrbl
+++ b/sketching-doc/sketching-doc/manual-sketching.scrbl
@@ -7271,22 +7271,28 @@ The form examples are:
 @local-table-of-contents[#:style 'immediate-only]
 
 @subsubsection[#:tag "example_points_and_lines"]{Points and Lines}
-@(example-from-file "basics/form/point-and-lines.rkt")
+@(p5example-from-file "basics/form/point-and-lines.js")
+@(example-from-file   "basics/form/point-and-lines.rkt")
 
 @subsubsection[#:tag "example_pie_chart"]{Pie Chart}
-@(example-from-file "basics/form/pie-chart.rkt")
+@(p5example-from-file "basics/form/pie-chart.js")
+@(example-from-file   "basics/form/pie-chart.rkt")
 
 @subsubsection[#:tag "example_regular_polygons"]{Regular Polygons}
-@(example-from-file "basics/form/regular-polygons.rkt")
+@(p5example-from-file "basics/form/regular-polygons.js")
+@(example-from-file   "basics/form/regular-polygons.rkt")
 
 @subsubsection[#:tag "example_start"]{Star}
-@(example-from-file "basics/form/star.rkt")
+@(p5example-from-file "basics/form/star.js")
+@(example-from-file   "basics/form/star.rkt")
 
 @subsubsection[#:tag "example_triangle_strip"]{Triangle Strip}
-@(example-from-file "basics/form/triangle-strip.rkt")
+@(p5example-from-file "basics/form/triangle-strip.js")
+@(example-from-file   "basics/form/triangle-strip.rkt")
 
 @subsubsection[#:tag "example_bezier"]{Bezier}
-@(example-from-file "basics/form/bezier.rkt")
+@(p5example-from-file "basics/form/bezier.js")
+@(example-from-file   "basics/form/bezier.rkt")
 
 
 

--- a/sketching-doc/sketching-doc/manual-sketching.scrbl
+++ b/sketching-doc/sketching-doc/manual-sketching.scrbl
@@ -11,7 +11,7 @@
                       second struct random round)
            sketching/exports-no-gui ; was sketching
            ))
-
+@(require scribble/core scribble/html-properties (only-in xml cdata))
 
 @; Used to reference other manuals.
 @(define reference.scrbl '(lib "scribblings/reference/reference.scrbl"))
@@ -45,8 +45,8 @@
    @hyperlink["https://github.com/soegaard/sketching/" "https://github.com/soegaard/sketching/"])
 
 @(define sketching-manual-examples-github
-   @hyperlink["https://github.com/soegaard/sketching/tree/main/sketching-examples/manual-examples/"
-              "https://github.com/soegaard/sketching/tree/main/sketching-examples/manual-examples/"])
+   @hyperlink["https://github.com/soegaard/sketching/tree/main/sketching-doc/sketching-doc/manual-examples/"
+              "https://github.com/soegaard/sketching/tree/main/sketching-doc/sketching-doc/manual-examples/"])
 
 
 @(begin
@@ -58,7 +58,7 @@
    ;; and use them instead in the text above.
    (define p-url "(https://github.com/processing/processing-docs/[^ \n]*)")
    (define r-url "(https://raw.githubusercontent.com/processing/processing-docs/[^ \n]*)")
-   (define s-url "https://github.com/soegaard/sketching/tree/main/sketching-examples/manual-examples/")
+   (define s-url "https://github.com/soegaard/sketching/tree/main/sketching-doc/sketching-doc/manual-examples/")
    (define url-found #f)
    (define (contains-long-url? s)
      (define result (or (regexp-match p-url s) (regexp-match r-url s)))
@@ -82,12 +82,44 @@
             @linebreak[]
             (if (and url-found (original-name url-found))
                 @hyperlink[url-found (list @bold{Original: } " " (original-name url-found))]
-                '()))))
-                
+                '())))
+   (define p5counter 0)
+   (define (p5example-from-file . examples)
+     (define example (first examples))
+     (set! p5counter (+ p5counter 1))
+     (define new-container (string-append "p5container" (number->string p5counter)))
+     (define (fix-container line) (regexp-replace "p5container" line new-container))
+     (define all-lines
+       (append* (for/list ([example examples])
+                  (define in (open-input-file (example->path example)))
+                  (for/list ([line (in-lines in)])
+                    (fix-container line)))))
+     (define code (string-append* (add-between all-lines "\n")))
+     (define p5example
+       (xexpr-property
+        ; Note: P5 sketches are in "global" mode, so in order to display more than one sketch at the same
+        ;       page, we need to embed the sketches in iframes. The alternative is to rewrite all the
+        ;       sketches.
+        (cdata #f #f (string-append 
+                      "<iframe width='640' height='360' srcdoc='<html><head>"
+                      "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.4/p5.min.js\"></script>"
+                      "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.4/addons/p5.dom.min.js\"></script>"
+                      "</head>"
+                      "<body><div id=\"p5container" (~a p5counter) "\"></div>"
+                      "<script type=\"text/javascript\">" code "</script>"
+                      "</body>"
+                      "'></html> </iframe>"
+                      ))
+        (cdata #f #f "")))     
+     @elem[#:style (style #f (list p5example)) example]))
 
-
-
-@title[#:tag "sketching"]{Sketching @linebreak[] A Language for Creative Coding}
+@(require (only-in scribble/core            style )
+          (only-in scribble/html-properties js-addition attributes)
+          (only-in net/url                  string->url))
+@(define p5-url    (string->url "https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.4/p5.min.js"))
+@(define p5dom-url (string->url "https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.4/addons/p5.dom.min.js"))
+@title[#:style (style #f (list (js-addition p5-url) (js-addition p5dom-url) (attributes '((lang . "en")))))
+       #:tag "sketching"]{Sketching @linebreak[] A Language for Creative Coding}
 
 @defmodule[sketching #:use-sources (sketching/exports-no-gui)]
 
@@ -7041,7 +7073,9 @@ is what we in everyday language think of, when we hear the word "color".
 
 Move the cursor vertically over each bar to alter its hue.
 
+@(p5example-from-file "basics/color/hue.js")
 @(example-from-file "basics/color/hue.rkt")
+
 
 @subsubsection[#:tag "example_saturation"]{Saturation}
 
@@ -7051,29 +7085,35 @@ A "saturated" color is pure and an "unsaturated" color has a large component of 
 
 Move the cursor vertically over each bar to alter its saturation.
 
-@(example-from-file "basics/color/saturation.rkt")
+@(p5example-from-file "basics/color/saturation.js")
+@(example-from-file   "basics/color/saturation.rkt")
+
 
 @subsubsection[#:tag "example_brightness"]{Brightness}
+Move the cursor vertically over each bar to alter its brightness.
+@(p5example-from-file "basics/color/brightness.js")
+@(example-from-file   "basics/color/brightness.rkt")
 
-This program adjusts the brightness of a part of the image by
-calculating the distance of each pixel to the mouse.
-
-@(example-from-file "basics/color/brightness.rkt")
 
 @subsubsection[#:tag "example_color_variables"]{Color Variables}
-@(example-from-file "basics/color/color-variables.rkt")
+@(p5example-from-file "basics/color/color-variables.js")
+@(example-from-file   "basics/color/color-variables.rkt")
 
 @subsubsection[#:tag "example_relativity"]{Relativity}
-@(example-from-file "basics/color/relativity.rkt")
+@(p5example-from-file "basics/color/relativity.js")
+@(example-from-file   "basics/color/relativity.rkt")
 
 @subsubsection[#:tag "example_linear_gradient"]{Linear Gradient}
-@(example-from-file "basics/color/linear-gradient.rkt")
+@(p5example-from-file "basics/color/linear-gradient.js")
+@(example-from-file   "basics/color/linear-gradient.rkt")
 
 @subsubsection[#:tag "example_radial_gradient"]{Radial Gradient}
-@(example-from-file "basics/color/radial-gradient.rkt")
+@(p5example-from-file "basics/color/radial-gradient.js")
+@(example-from-file   "basics/color/radial-gradient.rkt")
 
 @subsubsection[#:tag "example_wave_gradient"]{Wave Gradient}
-@(example-from-file "basics/color/wave-gradient.rkt")
+@(p5example-from-file "basics/color/wave-gradient.js")
+@(example-from-file   "basics/color/wave-gradient.rkt")
 
 
 @subsection[#:tag "examples_classes_and_objects"]{Classes and Objects}
@@ -7084,16 +7124,23 @@ The examples are:
 
 
 @subsubsection[#:tag "example_objects"]{Objects}
-@(example-from-file "basics/objects/objects.rkt")
+@(p5example-from-file "basics/objects/objects.js")
+@(example-from-file   "basics/objects/objects.rkt")
 
 @subsubsection[#:tag "example_multiple_constructors"]{Multiple Constructors}
-@(example-from-file "basics/objects/multiple-constructors.rkt")
+@(p5example-from-file "basics/objects/multiple-constructors.js")
+@(example-from-file   "basics/objects/multiple-constructors.rkt")
 
 @subsubsection[#:tag "example_composite_objects"]{Composite Objects}
-@(example-from-file "basics/objects/composite-objects.rkt")
+@(p5example-from-file "basics/objects/composite-objects.js"
+                      "basics/objects/egg.js"
+                      "basics/objects/ring.js"
+                      "basics/objects/egg-ring.js")
+@(example-from-file   "basics/objects/composite-objects.rkt")
 
 @subsubsection[#:tag "example_inheritance"]{Inheritance}
-@(example-from-file "basics/objects/inheritance.rkt")
+@(p5example-from-file "basics/objects/inheritance.js")
+@(example-from-file   "basics/objects/inheritance.rkt")
 
 
 @subsection[#:tag "examples_input"]{Input}
@@ -7104,40 +7151,52 @@ The input examples are:
 
 
 @subsubsection[#:tag "example_mouse_1d"]{Mouse 1D}
-@(example-from-file "basics/input/mouse-1d.rkt")
+@(p5example-from-file "basics/input/mouse-1d.js")
+@(example-from-file   "basics/input/mouse-1d.rkt")
 
 @subsubsection[#:tag "example_mouse_2d"]{Mouse 2D}
-@(example-from-file "basics/input/mouse-2d.rkt")
+@(p5example-from-file "basics/input/mouse-2d.js")
+@(example-from-file   "basics/input/mouse-2d.rkt")
 
 @subsubsection[#:tag "example_mouse_press"]{Mouse Press}
-@(example-from-file "basics/input/mouse-press.rkt")
+@(p5example-from-file "basics/input/mouse-press.js")
+@(example-from-file   "basics/input/mouse-press.rkt")
 
 @subsubsection[#:tag "example_mouse_signals"]{Mouse Signals}
-@(example-from-file "basics/input/mouse-signals.rkt")
+@(p5example-from-file "basics/input/mouse-signals.js")
+@(example-from-file   "basics/input/mouse-signals.rkt")
 
 @subsubsection[#:tag "example_easing"]{Easing}
-@(example-from-file "basics/input/easing.rkt")
+@(p5example-from-file "basics/input/easing.js")
+@(example-from-file   "basics/input/easing.rkt")
 
 @subsubsection[#:tag "example_constrain"]{Constrain}
-@(example-from-file "basics/input/constrain.rkt")
+@(p5example-from-file "basics/input/constrain.js")
+@(example-from-file   "basics/input/constrain.rkt")
 
 @subsubsection[#:tag "example_storing_inputs"]{Storing Input}
-@(example-from-file "basics/input/storing-input.rkt")
+@(p5example-from-file "basics/input/storing-input.js")
+@(example-from-file   "basics/input/storing-input.rkt")
 
 @subsubsection[#:tag "example_mouse_functions"]{Mouse Functions}
-@(example-from-file "basics/input/mouse-functions.rkt")
+@(p5example-from-file "basics/input/mouse-functions.js")
+@(example-from-file   "basics/input/mouse-functions.rkt")
 
 @subsubsection[#:tag "example_keyboard"]{Keyboard}
-@(example-from-file "basics/input/keyboard.rkt")
+@(p5example-from-file "basics/input/keyboard.js")
+@(example-from-file   "basics/input/keyboard.rkt")
 
 @subsubsection[#:tag "example_keyboard_functions"]{Keyboard Functions}
-@(example-from-file "basics/input/keyboard-functions.rkt")
+@(p5example-from-file "basics/input/keyboard-functions.js")
+@(example-from-file   "basics/input/keyboard-functions.rkt")
 
 @subsubsection[#:tag "example_milliseconds"]{Milliseconds}
-@(example-from-file "basics/input/milliseconds.rkt")
+@(p5example-from-file "basics/input/milliseconds.js")
+@(example-from-file   "basics/input/milliseconds.rkt")
 
 @subsubsection[#:tag "example_clock"]{Clock}
-@(example-from-file "basics/input/clock.rkt")
+@(p5example-from-file "basics/input/clock.js")
+@(example-from-file   "basics/input/clock.rkt")
 
 
 

--- a/sketching-doc/sketching-doc/manual-sketching.scrbl
+++ b/sketching-doc/sketching-doc/manual-sketching.scrbl
@@ -7208,16 +7208,20 @@ The examples using transformations are:
 
 
 @subsubsection[#:tag "example_translate"]{Translate}
-@(example-from-file "basics/transform/translate.rkt")
+@(p5example-from-file "basics/transform/translate.js")
+@(example-from-file   "basics/transform/translate.rkt")
 
 @subsubsection[#:tag "example_scale"]{Scale}
-@(example-from-file "basics/transform/scale.rkt")
+@(p5example-from-file "basics/transform/scale.js")
+@(example-from-file   "basics/transform/scale.rkt")
 
 @subsubsection[#:tag "example_rotate"]{Rotate}
-@(example-from-file "basics/transform/rotate.rkt")
+@(p5example-from-file "basics/transform/rotate.js")
+@(example-from-file   "basics/transform/rotate.rkt")
 
 @subsubsection[#:tag "example_arm"]{Arm}
-@(example-from-file "basics/transform/arm.rkt")
+@(p5example-from-file "basics/transform/arm.js")
+@(example-from-file   "basics/transform/arm.rkt")
 
 
 

--- a/sketching-doc/sketching-doc/manual-sketching.scrbl
+++ b/sketching-doc/sketching-doc/manual-sketching.scrbl
@@ -7232,13 +7232,16 @@ The typography examples are:
 @local-table-of-contents[#:style 'immediate-only]
 
 @subsubsection[#:tag "example_letters"]{Letters}
-@(example-from-file "basics/typography/letters.rkt")
+@(p5example-from-file "basics/typography/letters.js")
+@(example-from-file   "basics/typography/letters.rkt")
 
 @subsubsection[#:tag "example_words"]{Words}
-@(example-from-file "basics/typography/words.rkt")
+@(p5example-from-file "basics/typography/words.js")
+@(example-from-file   "basics/typography/words.rkt")
 
 @subsubsection[#:tag "example_text_rotation"]{Text Rotation}
-@(example-from-file "basics/typography/text-rotation.rkt")
+@(p5example-from-file "basics/typography/text-rotation.js")
+@(example-from-file   "basics/typography/text-rotation.rkt")
 
 
 @subsection[#:tag "examples_vectors"]{Vectors}

--- a/sketching-lib/sketching/class.rkt
+++ b/sketching-lib/sketching/class.rkt
@@ -3,7 +3,8 @@
 
 (provide Class Object
          ; from racket/class:
-         make-object new define/public define/override super-make-object inherit-field)
+         ; make-object new define/public define/override super-make-object inherit-field init-fields
+         (all-from-out racket/class))
 
 ;;;
 ;;; Simple Classes and Objects for Sketching

--- a/sketching-lib/sketching/exports-no-gui.rkt
+++ b/sketching-lib/sketching/exports-no-gui.rkt
@@ -186,6 +186,7 @@
  
  Object
  (all-from-out racket/class) ; class wasn't imported here
+ ; (except-out (all-from-out "class.rkt") class)
  ; define-method
  declare-struct-fields
  define-method

--- a/sketching-lib/sketching/graphics.rkt
+++ b/sketching-lib/sketching/graphics.rkt
@@ -399,14 +399,15 @@
   ; https://processing.org/reference/background_.html
   ; todo: allow image as background
   (define col (args->color args 'background))
-  (define reg (send dc get-clipping-region))
-  (send dc set-clipping-region #f)
-  ;(define old (send dc get-transformation))
-  ;(send dc set-transformation (vector (vector 1 0 0 1 0 0) 0 0 1 1 0))
-  (send dc set-background col)
-  (send dc clear)
-  ; (send dc set-transformation old)
-  (send dc set-clipping-region reg))
+  (when dc
+    (define reg (send dc get-clipping-region))
+    (send dc set-clipping-region #f)
+    ;(define old (send dc get-transformation))
+    ;(send dc set-transformation (vector (vector 1 0 0 1 0 0) 0 0 1 1 0))
+    (send dc set-background col)
+    (send dc clear)
+    ; (send dc set-transformation old)
+    (send dc set-clipping-region reg)))
 
 (define (smoothing mode)
   (send dc set-smoothing mode))


### PR DESCRIPTION
This series of commits adds P5.js examples to all examples in basics examples.

The function `background` now handles the situation where `dc` is #f.