### PR TITLE
fix unhex, so it treats hexadecimal as base 16 and not as base 2

### DIFF
--- a/sketching-lib/sketching/conversion.rkt
+++ b/sketching-lib/sketching/conversion.rkt
@@ -40,7 +40,7 @@
     [else (error 'hex "can't convert value to hexadecimal, got: ~a" x)]))
 
 (define (unhex s)
-  (string->number s 2))
+  (string->number s 16))
 
 (define (int x)
   (cond


### PR DESCRIPTION
Fixing #63