### PR TITLE
Support for shapes (PShapes) 

### DIFF
--- a/sketching-lib/sketching/exports-no-gui.rkt
+++ b/sketching-lib/sketching/exports-no-gui.rkt
@@ -306,7 +306,7 @@
  vertex
 
  ;; Shape
- shape%
+ Shape
  shape-create
  
  ;; Math

--- a/sketching-lib/sketching/exports-no-gui.rkt
+++ b/sketching-lib/sketching/exports-no-gui.rkt
@@ -55,7 +55,8 @@
          "noise.rkt"
          "parameters.rkt"
          "time-and-date.rkt"
-         "transform.rkt")
+         "transform.rkt"
+         "shape.rkt")
 
 
 
@@ -303,6 +304,10 @@
  tint
  triangle
  vertex
+
+ ;; Shape
+ shape%
+ shape-create
  
  ;; Math
  abs

--- a/sketching-lib/sketching/graphics.rkt
+++ b/sketching-lib/sketching/graphics.rkt
@@ -812,23 +812,45 @@
            (send path line-to (x p) (y p)))
          (when close?
            (send path close))
-         (define (draw dc [xt 0] [yt 0])
+         (define (draw dc [xt 0] [yt 0] [shape-fill #f] [shape-stroke #f])
+           (define old-fill (send dc get-brush))
+           (when shape-fill
+             (apply fill shape-fill))
+           (define old-stroke (send dc get-pen))
+           (when shape-stroke
+             (apply stroke shape-stroke))
            (send dc translate xt yt)
            (send dc draw-path path)
-           (send dc translate (- xt) (- yt)))
+           (send dc translate (- xt) (- yt))
+           (send dc set-brush old-fill)
+           (send dc set-pen old-stroke))
          (make-shape kind #f draw)]
         [(points)
-         (define (draw dc [xt 0] [yt 0])
+         (define (draw dc [xt 0] [yt 0] [shape-fill #f] [shape-stroke #f])
+           (define old-fill (send dc get-brush))
+           (when shape-fill
+             (apply fill shape-fill))
+           (define old-stroke (send dc get-pen))
+           (when shape-stroke
+             (apply stroke shape-stroke))
            (send dc translate xt yt)
            (for ([p points])
              (send dc draw-point (x p) (y p)))
-           (send dc translate (- xt) (- yt)))
+           (send dc translate (- xt) (- yt))
+           (send dc set-brush old-fill)
+           (send dc set-pen old-stroke))
          (make-shape kind #f draw)]
         [(lines)
          (define n (length points))
          ; skip the last point, if there is an odd number of points
          (set! points (if (even? n) points (reverse (rest rev-points))))
-         (define (draw dc [xt 0] [yt 0])
+         (define (draw dc [xt 0] [yt 0] [shape-fill #f] [shape-stroke #f])
+           (define old-fill (send dc get-brush))
+           (when shape-fill
+             (apply fill shape-fill))
+           (define old-stroke (send dc get-pen))
+           (when shape-stroke
+             (apply stroke shape-stroke))
            (send dc translate xt yt)
            (let loop ([ps points])
              (unless (empty? ps)
@@ -836,7 +858,9 @@
                (define q (second ps))
                (send dc draw-line (x p) (y p) (x q) (y q))
                (loop (rest (rest ps)))))
-           (send dc translate (- xt) (- yt)))
+           (send dc translate (- xt) (- yt))
+           (send dc set-brush old-fill)
+           (send dc set-pen old-stroke))
          (make-shape kind #f draw)]
         [(triangles)
          (define n (length points))
@@ -857,11 +881,19 @@
                    (send path line-to (x s) (y s))
                    (send path close)
                    (cons path (loop (rest (rest (rest ps)))))))))           
-         (define (draw dc [xt 0] [yt 0])
+         (define (draw dc [xt 0] [yt 0] [shape-fill #f] [shape-stroke #f])
+           (define old-fill (send dc get-brush))
+           (when shape-fill
+             (apply fill shape-fill))
+           (define old-stroke (send dc get-pen))
+           (when shape-stroke
+             (apply stroke shape-stroke))
            (send dc translate xt yt)
            (for ([path paths])
              (send dc draw-path path))
-           (send dc translate (- xt) (- yt)))
+           (send dc translate (- xt) (- yt))
+           (send dc set-brush old-fill)
+           (send dc set-pen old-stroke))
          (make-shape kind #f draw)]
         [(triangle-strip)
          (define n (length points))
@@ -881,12 +913,20 @@
                   (send path close)
                   (cons path
                         (loop q s (rest ps)))]))))
-         (define (draw dc [xt 0] [yt 0])
+         (define (draw dc [xt 0] [yt 0] [shape-fill #f] [shape-stroke #f])
+           (define old-fill (send dc get-brush))
+           (when shape-fill
+             (apply fill shape-fill))
+           (define old-stroke (send dc get-pen))
+           (when shape-stroke
+             (apply stroke shape-stroke))
            (send dc translate xt yt)
            (unless (< n 3)
              (for ([path paths])
                (send dc draw-path path)))
-           (send dc translate (- xt) (- yt)))
+           (send dc translate (- xt) (- yt))
+           (send dc set-brush old-fill)
+           (send dc set-pen old-stroke))
          (make-shape kind #f draw)]
         [(triangle-fan)
          (define n (length points))
@@ -906,12 +946,20 @@
                   (send path close)
                   (cons path
                         (loop p s (rest ps)))]))))
-         (define (draw dc [xt 0] [yt 0])
+         (define (draw dc [xt 0] [yt 0] [shape-fill #f] [shape-stroke #f])
+           (define old-fill (send dc get-brush))
+           (when shape-fill
+             (apply fill shape-fill))
+           (define old-stroke (send dc get-pen))
+           (when shape-stroke
+             (apply stroke shape-stroke))
            (send dc translate xt yt)
            (unless (< n 3)
              (for ([path paths])
                (send dc draw-path path)))
-           (send dc translate (- xt) (- yt)))
+           (send dc translate (- xt) (- yt))
+           (send dc set-brush old-fill)
+           (send dc set-pen old-stroke))
          (make-shape kind #f draw)]
         [(quads)
          (define n (length points))
@@ -934,11 +982,19 @@
                    (send path line-to (x s) (y s))
                    (send path close)
                    (cons path (loop (rest (rest (rest (rest ps))))))))))
-         (define (draw dc [xt 0] [yt 0])
+         (define (draw dc [xt 0] [yt 0] [shape-fill #f] [shape-stroke #f])
+           (define old-fill (send dc get-brush))
+           (when shape-fill
+             (apply fill shape-fill))
+           (define old-stroke (send dc get-pen))
+           (when shape-stroke
+             (apply stroke shape-stroke))
            (send dc translate xt yt)
            (for ([path paths])
              (send dc draw-path path))
-           (send dc translate (- xt) (- yt)))
+           (send dc translate (- xt) (- yt))
+           (send dc set-brush old-fill)
+           (send dc set-pen old-stroke))
          (make-shape kind #f draw)]
         [(quad-strip)
          (define n (length points))
@@ -960,19 +1016,27 @@
                   (send path close)
                   (cons path
                         (loop r s (rest (rest ps))))]))))
-         (define (draw dc [xt 0] [yt 0])
+         (define (draw dc [xt 0] [yt 0] [shape-fill #f] [shape-stroke #f])
+           (define old-fill (send dc get-brush))
+           (when shape-fill
+             (apply fill shape-fill))
+           (define old-stroke (send dc get-pen))
+           (when shape-stroke
+             (apply stroke shape-stroke))
            (send dc translate xt yt)
            (unless (< n 4)
              (for ([path paths])
                (send dc draw-path path)))
-           (send dc translate (- xt) (- yt)))
+           (send dc translate (- xt) (- yt))
+           (send dc set-brush old-fill)
+           (send dc set-pen old-stroke))
          (make-shape kind #f draw)]
         [else
          (error who (~a "internal error: got the kind " kind))])))
 
-(define (draw-shape shape [x 0] [y 0])
+(define (draw-shape shape [x 0] [y 0] [fill-args #f] [stroke-args #f])
   (define draw (shape-draw shape))
-  (when draw (draw dc x y)))
+  (when draw (draw dc x y fill-args stroke-args)))
 
 (define (begin-shape [kind 'default])
   (define old-shapes (current-shapes))

--- a/sketching-lib/sketching/shape.rkt
+++ b/sketching-lib/sketching/shape.rkt
@@ -18,8 +18,7 @@
       (if (not finalized)
         (set-shape-rev-points! shape-struct
                                (cons (cons x y) (shape-rev-points shape-struct)))
-        (error 'vertex "vertex can't be added to a finalized shape."))
-      (displayln (shape-rev-points shape-struct)))
+        (error 'vertex "vertex can't be added to a finalized shape.")))
     (define/public (begin-shape [kind 'default])
       (set! finalized #f)
       (set! shape-struct (new-shape kind)))

--- a/sketching-lib/sketching/shape.rkt
+++ b/sketching-lib/sketching/shape.rkt
@@ -1,0 +1,31 @@
+#lang racket/base
+
+(provide shape%
+         shape-create)
+
+(require racket/class
+         sketching/graphics)
+
+; shape% class to represent storable shapes.
+(define shape%
+  (class object%
+    (define-values (shape-struct finalized) (values #f #f))
+    (define/public (vertex x y)
+      (if (not finalized)
+        (set-shape-rev-points! shape-struct
+                               (cons (cons x y) (shape-rev-points shape-struct)))
+        (error 'vertex "vertex can't be added to a finalized shape."))
+      (displayln (shape-rev-points shape-struct)))
+    (define/public (begin-shape [kind 'default])
+      (set! finalized #f)
+      (set! shape-struct (new-shape kind)))
+    (define/public (end-shape [closed? #t])
+      (set! shape-struct (finish-shape shape-struct 'end-shape closed?))
+      (set! finalized #t))
+    (define/public (draw [x 0] [y 0])
+      (when finalized
+        (draw-shape shape-struct x y)))
+    (super-new)))
+
+(define (shape-create)
+  (new shape%))

--- a/sketching-lib/sketching/shape.rkt
+++ b/sketching-lib/sketching/shape.rkt
@@ -9,7 +9,11 @@
 ; shape% class to represent storable shapes.
 (define shape%
   (class object%
-    (define-values (shape-struct finalized) (values #f #f))
+    (define-values (shape-struct
+                    finalized
+                    visible) (values #f
+                                     #f
+                                     #t))
     (define/public (vertex x y)
       (if (not finalized)
         (set-shape-rev-points! shape-struct
@@ -23,8 +27,12 @@
       (set! shape-struct (finish-shape shape-struct 'end-shape closed?))
       (set! finalized #t))
     (define/public (draw [x 0] [y 0])
-      (when finalized
+      (when (and finalized visible)
         (draw-shape shape-struct x y)))
+    (define/public (visible?)
+      visible)
+    (define/public (set-visible v)
+      (set! visible v))
     (super-new)))
 
 (define (shape-create)

--- a/sketching-lib/sketching/shape.rkt
+++ b/sketching-lib/sketching/shape.rkt
@@ -11,27 +11,66 @@
   (class object%
     (define-values (shape-struct
                     finalized
-                    visible) (values #f
-                                     #f
-                                     #t))
-    (define/public (vertex x y)
-      (if (not finalized)
-        (set-shape-rev-points! shape-struct
-                               (cons (cons x y) (shape-rev-points shape-struct)))
-        (error 'vertex "vertex can't be added to a finalized shape.")))
+                    visible
+                    children
+                    child-count
+                    vertex-count
+                    fill-args
+                    stroke-args
+                    translation) (values  #f ; shape-struct
+                                          #f ; finalized
+                                          #t ; visible
+                                          '() ; children
+                                          0 ; child-count
+                                          0 ; vertex-count
+                                          #f; fill-args
+                                          #f; stroke-args
+                                          (cons 0 0) ;translation
+                                        ))
     (define/public (begin-shape [kind 'default])
       (set! finalized #f)
       (set! shape-struct (new-shape kind)))
     (define/public (end-shape [closed? #t])
       (set! shape-struct (finish-shape shape-struct 'end-shape closed?))
       (set! finalized #t))
+    (define/public (vertex x y)
+      (if (not finalized)
+          (begin
+            (set! vertex-count (add1 vertex-count))
+            (set-shape-rev-points! shape-struct
+                                   (cons (cons x y) (shape-rev-points shape-struct))))
+          (error 'vertex "vertex can't be added to a finalized shape.")))
+    (define/public (get-vertex-count)
+      vertex-count)
     (define/public (draw [x 0] [y 0])
       (when (and finalized visible)
-        (draw-shape shape-struct x y)))
+        (define tx (+ (car translation) x))
+        (define ty (+ (cdr translation) y))
+        (draw-shape shape-struct tx ty fill-args stroke-args)
+        (for ([c children])
+          (send c draw x y))))
     (define/public (visible?)
       visible)
     (define/public (set-visible v)
       (set! visible v))
+    (define/public (get-child-count)
+      child-count)
+    (define/public (add-child child)
+      (set! child-count (add1 child-count))
+      (set! children (cons child children)))
+    (define/public (get-child index)
+      (if (>= index child-count)
+          (error 'get-child "index is greater or equal than the number of children: index: ~a, child-count: ~a" index child-count)
+          (list-ref children index)))
+    (define/public (remove-children)
+      (set! child-count 0)
+      (set! children '()))
+    (define/public (set-fill . args)
+      (set! fill-args args))
+    (define/public (set-stroke . args)
+      (set! stroke-args args))
+    (define/public (translate x y)
+      (set! translation (cons x y)))
     (super-new)))
 
 (define (shape-create)

--- a/sketching-lib/sketching/shape.rkt
+++ b/sketching-lib/sketching/shape.rkt
@@ -7,7 +7,7 @@
          sketching/graphics
          sketching/transform)
 
-; shape% class to represent storable shapes.
+; Shape class to represent storable shapes.
 (define Shape
   (class object%
     (define-values (shape-struct

--- a/sketching-lib/sketching/transform.rkt
+++ b/sketching-lib/sketching/transform.rkt
@@ -15,7 +15,14 @@
          set-matrix
          apply-matrix
          shear-x
-         shear-y)
+         shear-y
+         translation-matrix
+         scaling-matrix
+         rotation-matrix
+         new-matrix
+         matrix->transformation
+         transformation->matrix
+         transformation)
 
 ;;; Implementation Notes
 


### PR DESCRIPTION
Here is a implementation for a big chunk of #10, I just wanted to check if this is the right direction or if anything should be changed. I played around with it and everything seems to work. I did no automated systematic testing. I just created some shapes and played around with them.

The following things are implemented from the original Processing Pshape:

- is-visible
- set-visible
- begin-shape
- end-shape
- get-child-count
- get-child
- add-child
- remove-children (this is not in processing but I think it's nice to have)
- get-vertex-count
- set-fill
- set-stroke
- translate

The following things are missing:
- rotations
- scaling
- reset-matrix
- styles (I don't know if sketching supports this)
- contour (")
- load-shape (This is for SVGs, and I have no idea how to do this)

I tried to use as much as possible from the shape struct, so I had to augment the function calls with optional arguments and I don't know if it would be better to duplicate code or to add optional arguments to functions. I think duplicated code is worse than multiple optionals. But I am by far no experienced Racketeer and I will change it if it is bad this way.

A example on using the shape class:

```scheme
#lang sketching

(define s1 (shape-create))

(define (setup)
  (frame-rate 144)
  (size 500 500)
  (send s1 begin-shape 'quad-strip)
  (send s1 vertex 0 0)
  (send s1 vertex 50 0)
  (send s1 vertex 0 50)
  (send s1 vertex 50 50)
  (send s1 end-shape)
  (send s1 set-fill 0 0 255 100)
  (send s1 set-stroke 255 0 0 255)
  (send s1 translate 500 500))

(define (draw)
  (background 255)
  (text-size 16)
  (fill 123 12 44 255)
  (text (format "~a" frame-rate) 100 100)
  (send s1 draw mouse-x mouse-y))
```